### PR TITLE
Fix broken highlighting if string contain ' or "

### DIFF
--- a/syntaxes/inno-setup.tmLanguage
+++ b/syntaxes/inno-setup.tmLanguage
@@ -136,7 +136,7 @@
         <!-- Quoted Strings -->
         <dict>
             <key>begin</key>
-            <string>"</string>
+            <string>^(?!.*=)"</string>
             <key>beginCaptures</key>
             <dict>
                 <key>0</key>
@@ -175,7 +175,7 @@
         </dict>
         <dict>
             <key>begin</key>
-            <string>'</string>
+            <string>^(?!.*=)'</string>
             <key>beginCaptures</key>
             <dict>
                 <key>0</key>

--- a/syntaxes/inno-setup.tmLanguage
+++ b/syntaxes/inno-setup.tmLanguage
@@ -136,7 +136,7 @@
         <!-- Quoted Strings -->
         <dict>
             <key>begin</key>
-            <string>^(?!.*=)"</string>
+            <string>(?<!\=.*)"</string>
             <key>beginCaptures</key>
             <dict>
                 <key>0</key>
@@ -175,7 +175,7 @@
         </dict>
         <dict>
             <key>begin</key>
-            <string>^(?!.*=)'</string>
+            <string>(?<!\=.*)'</string>
             <key>beginCaptures</key>
             <dict>
                 <key>0</key>


### PR DESCRIPTION
The origin implemention match `'` or `"` directly, this will cause broken highlighting if the string contain quotation marks, this patch won't match quotation marks if the line contain `=`


close #6 