### PR TITLE
Support highlighting pascal syntax in Code section

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,10 @@
             {
                 "language": "innosetup",
                 "scopeName": "source.inno",
-                "path": "./syntaxes/inno-setup.tmLanguage"
+                "path": "./syntaxes/inno-setup.tmLanguage",
+                "embeddedLanguages": {
+                    "source.pascal.embedded.inno": "pascal"
+                }
             },
             {
                 "language": "innopascal",


### PR DESCRIPTION
This patch add support syntax highlighting in [Code] section

You need install pascal extension first.

fix: https://github.com/idleberg/vscode-innosetup/issues/24