### PR TITLE
Rework taks provider and fix problem matcher if compile via tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
             {
                 "name": "innosetup-5-error",
                 "severity": "error",
-                "fileLocation": "absolute",
+                "fileLocation": "autoDetect",
                 "pattern": [
                     {
                         "regexp": "^Error on line (.*) in (.*): Column (.*).*$",
@@ -183,12 +183,12 @@
             {
                 "name": "innosetup-5-warning",
                 "severity": "warning",
-                "fileLocation": "absolute",
+                "fileLocation": "autoDetect",
                 "pattern": [
                     {
                         "regexp": "^Warning: (.*), Line (.*), Column (.*): (.*)$",
                         "file": 1,
-                        "location": 2,
+                        "line": 2,
                         "column": 3,
                         "message": 4
                     }
@@ -197,12 +197,13 @@
             {
                 "name": "innosetup-6-error",
                 "severity": "error",
-                "fileLocation": "absolute",
+                "fileLocation": "autoDetect",
                 "pattern": [
                     {
                         "regexp": "^Error on line (.*) in (.*): (.*)$",
                         "file": 2,
-                        "location": 1,
+                        "line": 1,
+                        "column": 1,
                         "message": 3
                     }
                 ]
@@ -210,7 +211,36 @@
         ],
         "taskDefinitions": [
             {
-                "type": "innosetup"
+                "type": "innosetup-build",
+                "required": [ "label", "command" ],
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": "The name of the task"
+                    },
+                    "command": {
+                        "type": "string",
+                        "description": "The path of innosetup compiler, default value is ISCC.exe"
+                    },
+                    "args": {
+                        "type": "array",
+                        "description": "Additional arguments to pass to the ISCC.exe, such as /Qp /O"
+                    },
+                    "options": {
+                        "type": "object",
+                        "description": "Additional command options",
+                        "properties": {
+                          "cwd": {
+                            "type": "string",
+                            "description": "The current working directory of the executed program or script. If omitted Code's current workspace root is used"
+                          }
+                        }
+                      },
+                      "detail": {
+                        "type": "string",
+                        "description": "Additional details of the task"
+                      }
+                }
             }
         ]
     },

--- a/src/buildTaskProvider.ts
+++ b/src/buildTaskProvider.ts
@@ -1,10 +1,23 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as cp from 'child_process';
+
+export interface BuildTaskDefinition extends vscode.TaskDefinition {
+    type: string;
+    label: string;
+    command: string;
+    args: string[];
+    options: cp.ExecOptions | undefined;
+}
 
 export class BuildTaskProvider implements vscode.TaskProvider {
-    public provideTasks(
-        token?: vscode.CancellationToken,
-    ): vscode.ProviderResult<vscode.Task[]> {
+    static buildScriptType = 'innosetup-build';
+    static buildSourceStr = 'innosetup';
+    private tasks: vscode.Task[] | undefined;
+    public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
+        if (this.tasks) {
+            return this.tasks;
+        }
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
             return [];
@@ -14,35 +27,42 @@ export class BuildTaskProvider implements vscode.TaskProvider {
         if (!isIssFile) {
             return [];
         }
-        const excutable =
-            vscode.workspace
-                .getConfiguration('innosetup')
-                .get<string>('pathToIscc') || '';
-        const execution = new vscode.ShellExecution(excutable, [
-            {
-                value: file,
-                quoting: vscode.ShellQuoting.Strong,
-            },
-        ]);
-        const taskDef = {
-            type: 'innosetup',
-        };
-        const task = new vscode.Task(
-            taskDef,
-            vscode.TaskScope.Workspace,
-            'compile script',
-            'innosetup',
-            execution,
-            ['innosetup-6-error', 'innosetup-5-error', 'innosetup-5-warning'],
-        );
-        task.source = 'innosetup';
-        task.group = vscode.TaskGroup.Build;
-        return [task];
+        const compilerPath = vscode.workspace.getConfiguration('innosetup').get<string>('pathToIscc') || '';
+        this.tasks = [this.getTask(compilerPath)];
+        return this.tasks;
     }
-    public resolveTask(
-        task: vscode.Task,
-        token?: vscode.CancellationToken,
-    ): vscode.ProviderResult<vscode.Task> {
+    public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
+        return this.getTask(task.definition.command, task.definition.args, task.definition as BuildTaskDefinition);
+    }
+
+    private getTask(compilerPath: string, compilerArgs?: string[], definition?: BuildTaskDefinition) {
+        const taskLabel = 'compile script';
+        const cwd = '${workspaceFolder}';
+        const args = compilerArgs && compilerArgs.length ? compilerArgs: ['${file}'];
+        const options: cp.ExecOptions | undefined = { cwd: cwd };
+        if (!definition) {
+            definition = {
+                type: BuildTaskProvider.buildScriptType,
+                label: taskLabel,
+                command: compilerPath,
+                args: args,
+                options: options,
+            };
+        }
+        const scope = vscode.TaskScope.Workspace;
+        const task = new vscode.Task(
+            definition,
+            scope,
+            taskLabel,
+            BuildTaskProvider.buildSourceStr,
+            new vscode.ShellExecution(compilerPath, args, {
+                cwd: cwd
+            }),
+            ['$innosetup-6-error', '$innosetup-5-error', '$innosetup-5-warning'],
+        );
+        task.group = vscode.TaskGroup.Build;
+        task.detail = 'compiler: ' + compilerPath;
+
         return task;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ async function activate(context: vscode.ExtensionContext): Promise<void> {
         ),
     );
     context.subscriptions.push(
-        vscode.tasks.registerTaskProvider('innosetup', new BuildTaskProvider()),
+        vscode.tasks.registerTaskProvider(BuildTaskProvider.buildScriptType, new BuildTaskProvider()),
     );
 
     hoverProvider.activate(context);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ const path = require('path');
 /**@type {import('webpack').Configuration}*/
 const config = {
   target: 'node',
-  mode: 'production',
   entry: './src/index.ts',
   output: {
     path: path.resolve(__dirname, 'lib'),


### PR DESCRIPTION
We can run compile via vscode tasks, but the problem matcher didn't work, this patch fix the problem.