### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.11.0 [#](https://github.com/chouzz/vscode-innosetup/releases/tag/v1.11.0)
+
+- Add three new DynamicDark directives to syntax highlighting (#132)
+
 # v1.10.0 [#](https://github.com/chouzz/vscode-innosetup/releases/tag/v1.10.0)
 
 - Add support for Inno Setup 6.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-innosetup",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-innosetup",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.7.7"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-innosetup",
     "displayName": "Inno Setup",
     "description": "Language syntax, snippets and build system for Inno Setup",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "icon": "images/icon.png",
     "publisher": "chouzz",
     "license": "MIT",


### PR DESCRIPTION
## Summary

Bump version from 1.10.0 to 1.11.0 and update CHANGELOG.md.

## Changes

- Update package.json version to 1.11.0
- Update package-lock.json version to 1.11.0
- Add v1.11.0 changelog entry for DynamicDark directives support

## Changelog

- Add three new DynamicDark directives to syntax highlighting (#132)