### PR TITLE
ci: upload vsix package to GitHub Release

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -68,6 +68,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extension-package
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ needs.build.outputs.vsixPath }}
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:


### PR DESCRIPTION
## Summary

Add a step to the publish job to automatically upload the .vsix package as a release asset when a GitHub Release is published.

## Changes

- Added `Upload to GitHub Release` step using `softprops/action-gh-release@v2`
- Placed after `Download Build Artifact` and before marketplace publish steps
- Uses the vsix path from build job output (`needs.build.outputs.vsixPath`)